### PR TITLE
Update erusev/parsedown to 1.8.0-beta-5 (was 1.8.0-beta-1)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^7.1|7.2",
-        "erusev/parsedown": "1.8.0-beta-1",
+        "erusev/parsedown": "1.8.0-beta-5",
         "scrivo/highlight.php": "v9.12.0.5"
     },
     "require-dev": {


### PR DESCRIPTION
## Status
**READY**

## Description
I justed updated the version of erusev/parsedown to the latest beta version (beta-5).

## Related PRs
none

## Todos
none

## Steps to Test or Reproduce
To test, just checkout this PR or update your composer.json to reflect the change from beta-1 to beta-5.