### PR TITLE
Use less specific constraint for highlight.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^7.1|7.2",
         "erusev/parsedown": "1.8.0-beta-5",
-        "scrivo/highlight.php": "v9.12.0.5"
+        "scrivo/highlight.php": "^9.14"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.10",


### PR DESCRIPTION
## Status
<!-- **READY/WIP/HOLD** -->
**READY**

## Description

I'd like to propose a less restrictive constraint for highlight.php. As it currently is, any user who depends on this project will be locked into [a version that doesn't support PHP 7.3](https://github.com/scrivo/highlight.php/issues/33) and have old language definitions (highlight.js has active development again).

By loosening up the constraint, it'll let users update highlight.php to newer versions so they can get the latest updates to language definitions and bug fixes. If backward compatibility is a concern, [we promise BC changes throughout major versions](https://github.com/scrivo/highlight.php#backward-compatibility-promise).

## Related PRs
List related PRs against other branches:

N/A

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Changelog Entry (unreleased)

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```bash
> git pull --prune
> git checkout <branch>
> vendor/bin/phpunit
```