### PR TITLE
Fix E_NOTICE errors

### DIFF
--- a/src/ParsedownHighlight.php
+++ b/src/ParsedownHighlight.php
@@ -17,6 +17,10 @@ class ParsedownHighlight extends Parsedown
 
     protected function blockFencedCodeComplete($block)
     {
+        if (! isset($block['element']['element']['attributes'])) {
+            return $block;
+        }
+
         $code = $block['element']['element']['text'];
         $languageClass = $block['element']['element']['attributes']['class'];
         $language = explode('-', $languageClass);


### PR DESCRIPTION
This fixes E_NOTICE errors when processing code blocks without language:
```
sixlive/parsedown-highlight/src/ParsedownHighlight.php:25 (E_NOTICE) Undefined offset: 1
sixlive/parsedown-highlight/src/ParsedownHighlight.php:21 (E_NOTICE) Undefined index: attributes
```
